### PR TITLE
Improve htpasswd backup security

### DIFF
--- a/htpasswd.php
+++ b/htpasswd.php
@@ -78,7 +78,11 @@ class Htpasswd {
             $lines[] = $line;
         }
         $this->backup();
-        file_put_contents($this->path, implode("\n", $lines) . "\n");
+        $data = implode("\n", $lines) . "\n";
+        if (file_put_contents($this->path, $data, LOCK_EX) === false) {
+            throw new RuntimeException('Unable to write htpasswd file');
+        }
+        @chmod($this->path, 0600);
     }
 
     public function backup() {
@@ -86,14 +90,23 @@ class Htpasswd {
             return;
         }
         if (!is_dir($this->backupDir)) {
-            mkdir($this->backupDir, 0777, true);
+            if (!mkdir($this->backupDir, 0700, true) && !is_dir($this->backupDir)) {
+                throw new RuntimeException('Unable to create backup directory');
+            }
+        } else {
+            @chmod($this->backupDir, 0700);
         }
         $backupFile = rtrim($this->backupDir, '/') . '/' . basename($this->path) . '.' . date('YmdHis');
         if (file_exists($this->path)) {
-            copy($this->path, $backupFile);
+            if (!copy($this->path, $backupFile)) {
+                throw new RuntimeException('Unable to create backup copy');
+            }
         } else {
-            file_put_contents($backupFile, '');
+            if (file_put_contents($backupFile, '') === false) {
+                throw new RuntimeException('Unable to create empty backup copy');
+            }
         }
+        @chmod($backupFile, 0600);
     }
 
     public function listBackups() {
@@ -124,9 +137,17 @@ class Htpasswd {
         if (!is_file($file)) {
             throw new InvalidArgumentException('Backup not found');
         }
+        $backupDirReal = realpath($this->backupDir);
+        $fileReal = realpath($file);
+        if ($backupDirReal === false || $fileReal === false || strpos($fileReal, $backupDirReal . DIRECTORY_SEPARATOR) !== 0) {
+            throw new InvalidArgumentException('Invalid backup file');
+        }
         $data = file_get_contents($file);
         $this->backup();
-        file_put_contents($this->path, $data);
+        if (file_put_contents($this->path, $data, LOCK_EX) === false) {
+            throw new RuntimeException('Unable to restore htpasswd file');
+        }
+        @chmod($this->path, 0600);
     }
 }
 ?>

--- a/tests/htpasswd_test.php
+++ b/tests/htpasswd_test.php
@@ -9,9 +9,10 @@ $sample = "" .
 "# user2:\$hash2\n";
 
 $file = tempnam(sys_get_temp_dir(), 'htp');
+$backupDir = sys_get_temp_dir() . '/htp_' . uniqid();
 file_put_contents($file, $sample);
 
-$ht = new Htpasswd($file, sys_get_temp_dir());
+$ht = new Htpasswd($file, $backupDir);
 $entries = $ht->read();
 
 assert(count($entries) === 2);
@@ -27,13 +28,33 @@ assert($entries[1]['comments'] === ['disabled comment']);
 $ht->write($entries);
 $written = file_get_contents($file);
 assert($written === $sample);
+$perms = fileperms($file) & 0777;
+assert($perms === 0600);
 $list = $ht->listBackups();
 assert(count($list) >= 1);
+$backupPath = rtrim($backupDir, '/') . '/' . $list[0]['file'];
+$backupPerms = fileperms($backupPath) & 0777;
+assert($backupPerms === 0600);
 file_put_contents($file, 'broken');
 $ht->restore($list[0]['file']);
 assert(file_get_contents($file) === $sample);
-$all = glob(sys_get_temp_dir() . '/' . basename($file) . '.*');
+$perms = fileperms($file) & 0777;
+assert($perms === 0600);
+
+$symlink = $backupDir . '/malicious';
+symlink(__FILE__, $symlink);
+$caught = false;
+try {
+    $ht->restore(basename($symlink));
+} catch (InvalidArgumentException $ex) {
+    $caught = true;
+}
+assert($caught);
+unlink($symlink);
+
+$all = glob($backupDir . '/' . basename($file) . '.*');
 foreach ($all as $b) { unlink($b); }
+@rmdir($backupDir);
 
 $bad = $entries;
 $bad[0]['username'] = 'bad name';


### PR DESCRIPTION
## Summary
- ensure htpasswd files and backups are written with strict permissions and checked for errors
- harden restore() against symlink traversal when selecting backup files
- extend unit tests to cover new security protections

## Testing
- php tests/htpasswd_test.php

------
https://chatgpt.com/codex/tasks/task_e_690235e9b4ac8324bfee2939d49ade36